### PR TITLE
fix infinite loop when tinting image on load

### DIFF
--- a/geoq/core/static/core/js/jquery.tancolor.js
+++ b/geoq/core/static/core/js/jquery.tancolor.js
@@ -40,10 +40,13 @@
             img.src = settings.load;
             return;
         }
+
+        var load_later_function = function(){tintImage(img,$(this),settings);};
+
         if (isImageOk(img)){
             tintImage(img,$(this),settings);
         } else {
-            img.addEventListener("load", function(){tintImage(img,$(this),settings);}, true);
+            img.addEventListener("load", load_later_function, true);
         }
 
         function tintImage(img,$img,settings){
@@ -204,7 +207,8 @@
             }
             ctx.putImageData(imageData,0,0);
 
-
+            // Remove the load event listener to fix infinite loop
+            img.removeEventListener("load", load_later_function, true); // MUST match addEventListener params as above perfectly
             //Write the changes back to the image
             var img_data = canvas.toDataURL("image/png");
             $img.attr('src',img_data);


### PR DESCRIPTION
Fixes GEOQ-18 - jquery.tancolor.js was creating infinite loop by adding "load" event listener which loaded an image, and so on. Fixes by un-registering the listener before we load the replacement tinted image.
