### PR TITLE
Fix background refresh

### DIFF
--- a/geoq/core/static/core/js/aoi_feature_edit.js
+++ b/geoq/core/static/core/js/aoi_feature_edit.js
@@ -583,7 +583,12 @@ aoi_feature_edit.map_init = function (map, bounds) {
     aoi_feature_edit.layers.overlays = [];
     aoi_feature_edit.layers.jobs = [];
 
-    //Add the Base OSM Layer
+
+    
+    // aoi_feature_edit.map._layers - layers that have been added to the map already
+    // map.options.djoptions.layers - layer options that were passed to django
+    // Set the name for the base layer and add it to our layer map.
+    // (It seems like it's possible to have multiple base maps, but that's not handled here)
     var baselayer = _.toArray(aoi_feature_edit.map._layers);
     if (baselayer && baselayer[0]) {
         baselayer[0].name=(map.options.djoptions.layers[0]) ? map.options.djoptions.layers[0][0] : "Base Layer";
@@ -602,10 +607,11 @@ aoi_feature_edit.map_init = function (map, bounds) {
         });
     aoi_extents.addTo(aoi_feature_edit.map);
     aoi_feature_edit.layers.features.push(aoi_extents);
+
     //Build a reset button that zooms to the extents of the AOI
     function locateBounds() {
         return aoi_extents.getBounds();
-    }
+    };
     (new L.Control.ResetView(locateBounds)).addTo(aoi_feature_edit.map);
 
     //Zoom to the bounds of the Workcell, then one more level
@@ -640,6 +646,7 @@ aoi_feature_edit.map_init = function (map, bounds) {
             // 
 
             if (layer_data.isBaseLayer) {
+                // FIXME - custom base layers get duplicated here. (although they get skipped later, still not ideal)
                 aoi_feature_edit.layers.base.push(built_layer);
             } else {
                 if (layer_data.job) {

--- a/geoq/core/static/core/js/aoi_feature_edit.js
+++ b/geoq/core/static/core/js/aoi_feature_edit.js
@@ -664,14 +664,14 @@ aoi_feature_edit.map_init = function (map, bounds) {
                 try {
                     aoi_feature_edit.watch_layer(built_layer, true);
                     aoi_feature_edit.map.addLayer(built_layer);
-                    var shownAmount = shouldBeShown ? built_layer.options.opacity || 0.8 : 0;
+                    var shownAmount = built_layer.options.opacity;
 
                     //TODO: Some layers are showing even when unchecked.  Find out why
 
                     built_layer.options.toShowOnLoad = shownAmount;
                     built_layer.options.setInitialOpacity = false;
 
-                    leaflet_layer_control.setLayerOpacity(built_layer, shownAmount, true);
+                    leaflet_layer_control.setLayerOpacity(built_layer, shownAmount, true); // FIXME - if i comment this out, everything is selected always
                 } catch (e) {
                     log.warn("Error trying to add layer: " + built_layer.name);
                 }

--- a/geoq/core/static/core/js/aoi_feature_edit.js
+++ b/geoq/core/static/core/js/aoi_feature_edit.js
@@ -618,8 +618,7 @@ aoi_feature_edit.map_init = function (map, bounds) {
     aoi_feature_edit.map.fitBounds(aoi_extents.getBounds());
     aoi_feature_edit.map.setZoom(aoi_feature_edit.map.getZoom()+1);
 
-    var layers_to_show = store.get('leaflet_layer_control.layers');
-    layers_to_show = layers_to_show ? layers_to_show.split(",") : undefined;
+    var layersToShow = store.get('leaflet_layer_control.selected_tree_nodes');
 
     //Build layers, parse them, and add them to the map and to memory
     if (custom_map.layers) {
@@ -634,20 +633,9 @@ aoi_feature_edit.map_init = function (map, bounds) {
                 return true;
             }
 
-            // I think this can be removed FIXME
-            var shouldBeShown;
-            if (layers_to_show) {
-                shouldBeShown = _.indexOf(layers_to_show, built_layer.config.id+"");
-                shouldBeShown = shouldBeShown >= 0;
-            } else {
-                shouldBeShown = built_layer.config.shown;
-            }
-            built_layer.shown = shouldBeShown;
-            // 
-
             if (layer_data.isBaseLayer) {
-                // FIXME - custom base layers get duplicated here. (although they get skipped later, still not ideal)
-                aoi_feature_edit.layers.base.push(built_layer);
+                // Don't add base layers here, we should assume that base layers are properly added to the map by django
+                // aoi_feature_edit.layers.base.push(built_layer);
             } else {
                 if (layer_data.job) {
                     aoi_feature_edit.layers.jobs.push(built_layer);

--- a/geoq/core/static/core/js/aoi_feature_edit.js
+++ b/geoq/core/static/core/js/aoi_feature_edit.js
@@ -588,7 +588,7 @@ aoi_feature_edit.map_init = function (map, bounds) {
     // aoi_feature_edit.map._layers - layers that have been added to the map already
     // map.options.djoptions.layers - layer options that were passed to django
     // Set the name for the base layer and add it to our layer map.
-    // (It seems like it's possible to have multiple base maps, but that's not handled here)
+    // TODO: It seems like it's possible to have multiple base maps, but that's not handled here
     var baselayer = _.toArray(aoi_feature_edit.map._layers);
     if (baselayer && baselayer[0]) {
         baselayer[0].name=(map.options.djoptions.layers[0]) ? map.options.djoptions.layers[0][0] : "Base Layer";

--- a/geoq/core/static/core/js/aoi_feature_edit.js
+++ b/geoq/core/static/core/js/aoi_feature_edit.js
@@ -14,9 +14,10 @@
 //            style_obj.schema (array of {properties:options} and others)
 
 //            feature.properties.mapText = "Whatever"
+//            
 
 var aoi_feature_edit = {};
-aoi_feature_edit.layers = {features:[], base:[], overlays:[], jobs:[]};
+aoi_feature_edit.layers = {features: [], base: [], overlays: [], jobs: []};
 
 aoi_feature_edit.drawnItems = new L.FeatureGroup();
 aoi_feature_edit.options = {};
@@ -514,12 +515,13 @@ aoi_feature_edit.layer_oversight = {
   failing: []
 };
 aoi_feature_edit.watch_layer = function(layer, watch) {
+    "use strict";
     //TODO: Clean this up
-    oversight = aoi_feature_edit.layer_oversight;
-    name = layer.name;
-    pending = oversight.pending;
-    watched = oversight.watched;
-    failing = oversight.failing;
+    var oversight = aoi_feature_edit.layer_oversight;
+    var name = layer.name;
+    var pending = oversight.pending;
+    var watched = oversight.watched;
+    var failing = oversight.failing;
     if(watch) {
         if(watched.indexOf(name) < 0) watched[watched.length] = name;
         layer.on("loading", function () {
@@ -563,10 +565,10 @@ aoi_feature_edit.watch_layer = function(layer, watch) {
 aoi_feature_edit._pendingPoints = {};
 aoi_feature_edit.map_init = function (map, bounds) {
 
-    map.on("layer_add", function(e) {
+    map.on("layeradd", function(e) {
         aoi_feature_edit.watch_layer(e.layer, true);
     });
-    map.on("layer_remove", function(e) {
+    map.on("layerremove", function(e) {
         aoi_feature_edit.watch_layer(e.layer, false);
     });
 
@@ -662,18 +664,23 @@ aoi_feature_edit.map_init = function (map, bounds) {
             if (built_layer) {
                 // we see errors here on bad layers. try to catch
                 try {
-                    aoi_feature_edit.watch_layer(built_layer, true);
-                    aoi_feature_edit.map.addLayer(built_layer);
-                    var shownAmount = built_layer.options.opacity;
+                    // FIXME - adding layers here results in hidden impossible to remove layers that create background network requests
+                    // Removing this means only layers in the layer picker show up!
+                    //aoi_feature_edit.watch_layer(built_layer, true);
+                    //aoi_feature_edit.map.addLayer(built_layer);
+                    //var shownAmount = built_layer.options.opacity;
 
                     //TODO: Some layers are showing even when unchecked.  Find out why
 
-                    built_layer.options.toShowOnLoad = shownAmount;
-                    built_layer.options.setInitialOpacity = false;
+                    //built_layer.options.toShowOnLoad = shownAmount;
+                    //built_layer.options.setInitialOpacity = false;
 
-                    leaflet_layer_control.setLayerOpacity(built_layer, shownAmount, true); // FIXME - if i comment this out, everything is selected always
+                    //leaflet_layer_control.setLayerOpacity(built_layer, shownAmount, true); 
                 } catch (e) {
                     log.warn("Error trying to add layer: " + built_layer.name);
+                    if (console) {
+                        console.error(e);
+                    }
                 }
             }
         });
@@ -817,7 +824,7 @@ aoi_feature_edit.map_init = function (map, bounds) {
         var headers = {};
         geojson.properties.template = aoi_feature_edit.current_feature_type_id || 1;
         if(geojson.geometry.type === "Point") {
-            icon = null;
+            var icon = null;
             var tmpId = Math.uuidCompact();
             headers = { "Temp-Point-Id": tmpId};
             if(aoi_feature_edit.feature_types[geojson.properties.template]) {

--- a/geoq/core/static/core/js/aoi_feature_edit.js
+++ b/geoq/core/static/core/js/aoi_feature_edit.js
@@ -586,7 +586,7 @@ aoi_feature_edit.map_init = function (map, bounds) {
     //Add the Base OSM Layer
     var baselayer = _.toArray(aoi_feature_edit.map._layers);
     if (baselayer && baselayer[0]) {
-        baselayer[0].name=baseLayerName;
+        baselayer[0].name=(map.options.djoptions.layers[0]) ? map.options.djoptions.layers[0][0] : "Base Layer";
         aoi_feature_edit.layers.base.push(baselayer[0]);
     }
 
@@ -624,6 +624,7 @@ aoi_feature_edit.map_init = function (map, bounds) {
             var built_layer = leaflet_helper.layer_conversion(layer_data, map);
             if (! built_layer) {
                 // skip this layer and go to next
+                log.error("Tried to add a layer, but didn't work: "+layer_data.url)
                 return true;
             }
 
@@ -638,44 +639,15 @@ aoi_feature_edit.map_init = function (map, bounds) {
             built_layer.shown = shouldBeShown;
             // 
 
-            if (built_layer !== undefined) {
-                if (layer_data.isBaseLayer) {
-                    aoi_feature_edit.layers.base.push(built_layer);
-                } else {
-                    if (layer_data.job) {
-                        aoi_feature_edit.layers.jobs.push(built_layer);
-                    } else {
-                        aoi_feature_edit.layers.overlays.push(built_layer);
-                    }
-                }
+            if (layer_data.isBaseLayer) {
+                aoi_feature_edit.layers.base.push(built_layer);
             } else {
-                log.error("Tried to add a layer, but didn't work: "+layer_data.url)
-            }
-
-            // I think all layers that are passed in here get added when we add them to the layer picker
-            /*
-            if (built_layer) {
-                // we see errors here on bad layers. try to catch
-                try {
-                    // FIXME - adding layers here results in hidden impossible to remove layers that create background network requests
-                    // Removing this means only layers in the layer picker show up!
-                    //aoi_feature_edit.watch_layer(built_layer, true);
-                    //aoi_feature_edit.map.addLayer(built_layer);
-                    //var shownAmount = built_layer.options.opacity;
-
-                    //TODO: Some layers are showing even when unchecked.  Find out why
-
-                    //built_layer.options.toShowOnLoad = shownAmount;
-                    //built_layer.options.setInitialOpacity = false;
-
-                    //leaflet_layer_control.setLayerOpacity(built_layer, shownAmount, true); 
-                } catch (e) {
-                    log.warn("Error trying to add layer: " + built_layer.name);
-                    if (console) {
-                        console.error(e);
-                    }
+                if (layer_data.job) {
+                    aoi_feature_edit.layers.jobs.push(built_layer);
+                } else {
+                    aoi_feature_edit.layers.overlays.push(built_layer);
                 }
-            }*/
+            }
         });
     }
 

--- a/geoq/core/static/core/js/aoi_feature_edit.js
+++ b/geoq/core/static/core/js/aoi_feature_edit.js
@@ -565,6 +565,7 @@ aoi_feature_edit.watch_layer = function(layer, watch) {
 aoi_feature_edit._pendingPoints = {};
 aoi_feature_edit.map_init = function (map, bounds) {
 
+    // Events to watch layers being added/loaded/etc.
     map.on("layeradd", function(e) {
         aoi_feature_edit.watch_layer(e.layer, true);
     });
@@ -577,16 +578,6 @@ aoi_feature_edit.map_init = function (map, bounds) {
 
     var custom_map = aoi_feature_edit.aoi_map_json || {};
     aoi_feature_edit.map = map;
-
-    var baseLayers = {};
-    var layerSwitcher = {};
-
-    var baseLayerName = (map.options.djoptions.layers[0]) ? map.options.djoptions.layers[0][0] : "Base Layer";
-    //var editableLayers = new L.FeatureGroup();
-    // Only layer in here should be base OSM layer
-    _.each(aoi_feature_edit.map._layers, function (l) {
-        baseLayers[baseLayerName] = l;
-    });
 
     aoi_feature_edit.layers.base = [];
     aoi_feature_edit.layers.overlays = [];
@@ -636,6 +627,7 @@ aoi_feature_edit.map_init = function (map, bounds) {
                 return true;
             }
 
+            // I think this can be removed FIXME
             var shouldBeShown;
             if (layers_to_show) {
                 shouldBeShown = _.indexOf(layers_to_show, built_layer.config.id+"");
@@ -644,23 +636,24 @@ aoi_feature_edit.map_init = function (map, bounds) {
                 shouldBeShown = built_layer.config.shown;
             }
             built_layer.shown = shouldBeShown;
+            // 
 
             if (built_layer !== undefined) {
                 if (layer_data.isBaseLayer) {
-                    baseLayers[layer_data.name] = built_layer;
                     aoi_feature_edit.layers.base.push(built_layer);
                 } else {
                     if (layer_data.job) {
-                        layerSwitcher[layer_data.name] = built_layer;
                         aoi_feature_edit.layers.jobs.push(built_layer);
                     } else {
-                        layerSwitcher[layer_data.name] = built_layer;
                         aoi_feature_edit.layers.overlays.push(built_layer);
                     }
                 }
             } else {
                 log.error("Tried to add a layer, but didn't work: "+layer_data.url)
             }
+
+            // I think all layers that are passed in here get added when we add them to the layer picker
+            /*
             if (built_layer) {
                 // we see errors here on bad layers. try to catch
                 try {
@@ -682,7 +675,7 @@ aoi_feature_edit.map_init = function (map, bounds) {
                         console.error(e);
                     }
                 }
-            }
+            }*/
         });
     }
 

--- a/geoq/core/static/core/js/leaflet_helper.parsers.js
+++ b/geoq/core/static/core/js/leaflet_helper.parsers.js
@@ -432,7 +432,7 @@ leaflet_helper.constructors.geojson_success = function (data, proxiedURL, map, o
     if (outputLayer && !outputLayer.options) {
         outputLayer.options = {};
     }
-    outputLayer.options.opacity = 1;
+    if (!outputLayer.options.opacity) leaflet_layer_control.setLayerOpacity(outputLayer, 1);
 
     return outputLayer;
 };
@@ -533,8 +533,12 @@ leaflet_helper.parsers.basicJson = function (geojson, map, outputLayer, keepOld)
 
     return outputLayer;
 };
-leaflet_helper.parsers.fulcrum_exported_json = function (geojson, map, outputLayer) {
+leaflet_helper.parsers.fulcrum_exported_json = function (geojson, map, outputLayer, keepOld) {
     if (outputLayer) {
+        if (!keepOld) {
+            outputLayer.options.items = [];
+            outputLayer.clearLayers();
+        }
         outputLayer.options.onEachFeature = function(feature, layer) {
             aoi_feature_edit.fulcrumfeatureLayer_onEachFeature(feature, layer, outputLayer, true);
         };
@@ -564,8 +568,12 @@ leaflet_helper.parsers.fulcrum_exported_json = function (geojson, map, outputLay
 
     return outputLayer;
 };
-leaflet_helper.parsers.geoq_exported_json = function (geojson, map, outputLayer) {
+leaflet_helper.parsers.geoq_exported_json = function (geojson, map, outputLayer, keepOld) {
     if (outputLayer) {
+        if (!keepOld) {
+            outputLayer.options.items = [];
+            outputLayer.clearLayers();
+        }
         outputLayer.options.onEachFeature = function(feature, layer) {
             aoi_feature_edit.featureLayer_onEachFeature(feature, layer, outputLayer, true);
         };
@@ -599,12 +607,16 @@ leaflet_helper.parsers.geoq_exported_json = function (geojson, map, outputLayer)
     if (outputLayer && !outputLayer.options) {
         outputLayer.options = {};
     }
-    outputLayer.options.opacity = outputLayer.options.opacity || 1;
+    if (!outputLayer.options.opacity) leaflet_layer_control.setLayerOpacity(outputLayer, 1);
 
     return outputLayer;
 };
-leaflet_helper.parsers.leaflet_geojson = function (geojson, map, outputLayer) {
+leaflet_helper.parsers.leaflet_geojson = function (geojson, map, outputLayer, keepOld) {
     if (outputLayer) {
+        if (!keepOld) {
+            outputLayer.options.items = [];
+            outputLayer.clearLayers();
+        }
         outputLayer.options.onEachFeature = function(feature, layer) {
             aoi_feature_edit.featureLayer_onEachFeature(feature, layer, outputLayer, true);
         };
@@ -665,7 +677,7 @@ leaflet_helper.parsers.leaflet_geojson = function (geojson, map, outputLayer) {
     if (outputLayer && !outputLayer.options) {
         outputLayer.options = {};
     }
-    outputLayer.options.opacity = outputLayer.options.opacity || 1;
+    if (!outputLayer.options.opacity) leaflet_layer_control.setLayerOpacity(outputLayer, 1);
 
     return outputLayer;
 };

--- a/geoq/core/static/core/js/leaflet_helper.parsers.js
+++ b/geoq/core/static/core/js/leaflet_helper.parsers.js
@@ -432,7 +432,7 @@ leaflet_helper.constructors.geojson_success = function (data, proxiedURL, map, o
     if (outputLayer && !outputLayer.options) {
         outputLayer.options = {};
     }
-    if (!outputLayer.options.opacity) leaflet_layer_control.setLayerOpacity(outputLayer, 1);
+    //if (!outputLayer.options.opacity) leaflet_layer_control.setLayerOpacity(outputLayer, 1);
 
     return outputLayer;
 };
@@ -529,7 +529,7 @@ leaflet_helper.parsers.basicJson = function (geojson, map, outputLayer, keepOld)
     if (outputLayer && !outputLayer.options) {
         outputLayer.options = {};
     }
-    outputLayer.options.opacity = outputLayer.options.opacity || 1;
+    //outputLayer.options.opacity = outputLayer.options.opacity || 1;
 
     return outputLayer;
 };
@@ -564,7 +564,7 @@ leaflet_helper.parsers.fulcrum_exported_json = function (geojson, map, outputLay
     if (outputLayer && !outputLayer.options) {
         outputLayer.options = {};
     }
-    outputLayer.options.opacity = outputLayer.options.opacity || 1;
+    //outputLayer.options.opacity = outputLayer.options.opacity || 1;
 
     return outputLayer;
 };
@@ -607,7 +607,7 @@ leaflet_helper.parsers.geoq_exported_json = function (geojson, map, outputLayer,
     if (outputLayer && !outputLayer.options) {
         outputLayer.options = {};
     }
-    if (!outputLayer.options.opacity) leaflet_layer_control.setLayerOpacity(outputLayer, 1);
+    //if (!outputLayer.options.opacity) leaflet_layer_control.setLayerOpacity(outputLayer, 1);
 
     return outputLayer;
 };
@@ -677,7 +677,7 @@ leaflet_helper.parsers.leaflet_geojson = function (geojson, map, outputLayer, ke
     if (outputLayer && !outputLayer.options) {
         outputLayer.options = {};
     }
-    if (!outputLayer.options.opacity) leaflet_layer_control.setLayerOpacity(outputLayer, 1);
+    //if (!outputLayer.options.opacity) leaflet_layer_control.setLayerOpacity(outputLayer, 1);
 
     return outputLayer;
 };

--- a/geoq/core/static/core/js/leaflet_helper.parsers.js
+++ b/geoq/core/static/core/js/leaflet_helper.parsers.js
@@ -298,9 +298,7 @@ leaflet_helper.constructors.geojson = function(layerConfig, map, useLayerInstead
     }
 
     var opacity = 1;
-    if (outputLayer.config) {
-        opacity = outputLayer.config.shown ? outputLayer.config.opacity : 0;
-    }
+    if (outputLayer.config) opacity = (outputLayer.config.opacity !== undefined) ? outputLayer.config.opacity : opacity;
 
     outputLayer.options = $.extend(outputLayer.options, layerConfig.layerParams);
 
@@ -318,7 +316,7 @@ leaflet_helper.constructors.geojson = function(layerConfig, map, useLayerInstead
         success: function(data){
             leaflet_helper.constructors.geojson_success(data, proxiedURL, map, outputLayer);
             // try to set correct opacity
-                leaflet_layer_control.setLayerOpacity(outputLayer, outputLayer.options.toShowOnLoad, true);
+                leaflet_layer_control.setLayerOpacity(outputLayer, outputLayer.options.opacity, true);
         },
         error: leaflet_helper.constructors.geojson_error
     });
@@ -432,7 +430,6 @@ leaflet_helper.constructors.geojson_success = function (data, proxiedURL, map, o
     if (outputLayer && !outputLayer.options) {
         outputLayer.options = {};
     }
-    //if (!outputLayer.options.opacity) leaflet_layer_control.setLayerOpacity(outputLayer, 1);
 
     return outputLayer;
 };
@@ -529,7 +526,6 @@ leaflet_helper.parsers.basicJson = function (geojson, map, outputLayer, keepOld)
     if (outputLayer && !outputLayer.options) {
         outputLayer.options = {};
     }
-    //outputLayer.options.opacity = outputLayer.options.opacity || 1;
 
     return outputLayer;
 };
@@ -564,7 +560,6 @@ leaflet_helper.parsers.fulcrum_exported_json = function (geojson, map, outputLay
     if (outputLayer && !outputLayer.options) {
         outputLayer.options = {};
     }
-    //outputLayer.options.opacity = outputLayer.options.opacity || 1;
 
     return outputLayer;
 };
@@ -607,7 +602,6 @@ leaflet_helper.parsers.geoq_exported_json = function (geojson, map, outputLayer,
     if (outputLayer && !outputLayer.options) {
         outputLayer.options = {};
     }
-    //if (!outputLayer.options.opacity) leaflet_layer_control.setLayerOpacity(outputLayer, 1);
 
     return outputLayer;
 };
@@ -677,7 +671,6 @@ leaflet_helper.parsers.leaflet_geojson = function (geojson, map, outputLayer, ke
     if (outputLayer && !outputLayer.options) {
         outputLayer.options = {};
     }
-    //if (!outputLayer.options.opacity) leaflet_layer_control.setLayerOpacity(outputLayer, 1);
 
     return outputLayer;
 };

--- a/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
+++ b/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
@@ -688,7 +688,7 @@ leaflet_layer_control.show_info = function (objToShow, node) {
     if (typeof objToShow == "string"){
         html_objects.push(objToShow);
     } else {
-        if (objToShow.options && objToShow._leaflet_id) {
+        if (objToShow.options) {
             //Probably a Leaflet layer
             html_objects.push(leaflet_layer_control.parsers.infoFromLayer(objToShow));
             html_objects.push(leaflet_layer_control.parsers.opacityControls(objToShow));

--- a/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
+++ b/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
@@ -1517,8 +1517,9 @@ leaflet_layer_control.drawEachLayer=function(data,map,doNotMoveToTop){
                     layer = _.find(_.flatten(aoi_feature_edit.layers),function(l){return l.name==layer.name});
 
                     if (layer == null) {
-                        log.error("Lost reference to ESRI Dynamic Map Layer!");
+                        log.error("Couldn't recover lost reference to ESRI Dynamic Map Layer!");
                     } else {
+                        log.warn("Recovered lost reference to ESRI Dynamic Map Layer!");
                         layer_obj.data = layer; // Save the reference
                     }
                 }

--- a/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
+++ b/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
@@ -1620,8 +1620,12 @@ leaflet_layer_control._getLayerStorageID = function(layerTreeNode) {
 }
 
 leaflet_layer_control._uninit_getLayerStorageID = function(uninitTreeNode, uninitTreeGroup) {
+    // Get the layer id if it exists, otherwise get the folder it's in
     if (uninitTreeNode.data && uninitTreeNode.data.config && uninitTreeNode.data.config.id) {
         return uninitTreeNode.data.config.id;
+    } else if (uninitTreeNode.data && uninitTreeNode.data.id) {
+        // Social media feeds seem to have id set in data when uninitialized, then copied over to config after initialized.
+        return uninitTreeNode.data.id;
     } else {
         return 'root:' + uninitTreeGroup.title + ":" + uninitTreeNode.title;
     }

--- a/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
+++ b/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
@@ -1123,23 +1123,8 @@ leaflet_layer_control.layerDataList = function (options) {
                     showEvenIfNotInUS = false;
                 }
 
-                if (showEvenIfNotInUS || layerPreviouslyChosen) {// FIXME - this is what sets everything to checked!
-                    // if (layer.getLayers && layer.getLayers() && layer.getLayers()[0]) {
-                    //     var layerItem = layer.getLayers()[0];
-                    //     var options = layerItem._options || layerItem.options;
-                    //     if (options && options.style) {
-                    //         if (options.style.opacity == 1 || options.style.fillOpacity == 1){
-                    //             layer_obj.selected = true;
-                    //         }
-                    //     }
-                    //     if (options && options.opacity && options.opacity == 1) {
-                    //         layer_obj.selected = true;
-                    //     }
-                    // } else if (layer.options && layer.options.opacity){
-                    //     layer_obj.selected = true;
-                    // } else if (layer.options && layer.options.is_geoq_feature) {
-                    //     layer_obj.selected = true;
-                    // }
+                if (showEvenIfNotInUS || layerPreviouslyChosen) {
+                    // FIXME - doesn't work for Social Networking Feeds
                     if (layerPreviouslyChosen) layer_obj.selected = true;
                 }
                 // if (!layer_obj.selected) {
@@ -1456,7 +1441,7 @@ leaflet_layer_control.addLayerControl = function (map, options, $accordion) {
                 }
                 folders.shift();
             }
-            leaflet_layer_control.lastSelectedNodes = leafs;
+            //leaflet_layer_control.lastSelectedNodes = leafs; 
             leaflet_layer_control.drawEachLayer(data,map,true);
         },
         activate: function (event, data) {

--- a/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
+++ b/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
@@ -1429,9 +1429,7 @@ leaflet_layer_control.addLayerControl = function (map, options, $accordion) {
         selectMode: 3, // Hierarchecal select mode
         source: treeData,
         init: function (event, data) {
-            leaflet_layer_control.lastSelectedNodes = data.tree.getSelectedNodes();
-
-            
+            leaflet_layer_control.drawEachLayer(data, map);
         },
         activate: function (event, data) {
             //Clicked on a treenode title
@@ -1525,11 +1523,11 @@ leaflet_layer_control.drawEachLayer=function(data,map,doNotMoveToTop){
             if (layer._initHooksCalled) {
                 //It's a layer that's been already built
                 
-                aoi_feature_edit.map.addLayer(layer);
-
                 if (leaflet_layer_control.likelyHasFeatures(layer)) {
-                    leaflet_helper.constructors.geojson(layer.config, map);
+                    leaflet_helper.constructors.geojson(layer.config, map, layer);
                 }
+                
+                aoi_feature_edit.map.addLayer(layer);
             } else {
                 //It's an object with layer info, not yet built - build the layer from the config data
                 var name = layer.name;

--- a/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
+++ b/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
@@ -1429,20 +1429,9 @@ leaflet_layer_control.addLayerControl = function (map, options, $accordion) {
         selectMode: 3, // Hierarchecal select mode
         source: treeData,
         init: function (event, data) {
-            var folders = [data.tree.rootNode];
-            var leafs = [];
-            while (folders[0] && folders[0].children) {
-                for (var i = 0; i < folders[0].children.length; i++) {
-                    if (folders[0].children[i].children) {
-                        folders.push(folders[0].children[i]);
-                    } else {
-                        leafs.push(folders[0].children[i]);
-                    }
-                }
-                folders.shift();
-            }
-            //leaflet_layer_control.lastSelectedNodes = leafs; 
-            leaflet_layer_control.drawEachLayer(data,map,true);
+            leaflet_layer_control.lastSelectedNodes = data.tree.getSelectedNodes();
+
+            
         },
         activate: function (event, data) {
             //Clicked on a treenode title

--- a/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
+++ b/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
@@ -1436,6 +1436,19 @@ leaflet_layer_control.addLayerControl = function (map, options, $accordion) {
         selectMode: 3, // Hierarchecal select mode
         source: treeData,
         init: function (event, data) {
+            var folders = [data.tree.rootNode];
+            var leafs = [];
+            while (folders[0] && folders[0].children) {
+                for (var i = 0; i < folders[0].children.length; i++) {
+                    if (folders[0].children[i].children) {
+                        folders.push(folders[0].children[i]);
+                    } else {
+                        leafs.push(folders[0].children[i]);
+                    }
+                }
+                folders.shift();
+            }
+            leaflet_layer_control.lastSelectedNodes = leafs;
             leaflet_layer_control.drawEachLayer(data,map,true);
         },
         activate: function (event, data) {

--- a/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
+++ b/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
@@ -903,6 +903,7 @@ leaflet_layer_control.parsers.opacityControls = function(layer) {
  * HTML renderer for dynamic parameters controls in the side bar.
  */
 leaflet_layer_control.parsers.dynamicParamsControls = function(layer) {
+    "use strict";
     if (!layer || !layer.config || !layer.config.dynamicParams) {
         return undefined;
     }
@@ -929,6 +930,7 @@ leaflet_layer_control.parsers.dynamicParamsControls = function(layer) {
 leaflet_layer_control.parsers.dynamic_param_parsers = {};
 
 leaflet_layer_control.parsers.dynamic_param_parsers.__generic = function(layer, param, input) {
+    "use strict";
     var wrapper = document.createElement("div");
     wrapper.className = "input-append input-prepend";
 
@@ -955,6 +957,7 @@ leaflet_layer_control.parsers.dynamic_param_parsers.__generic = function(layer, 
 }
 
 leaflet_layer_control.parsers.dynamic_param_parsers.__group_box = function(layer, param, input) {
+    "use strict";
     var wrapper = document.createElement("div");
     wrapper.className = "geoq-param-group clearfix";
     
@@ -980,6 +983,7 @@ leaflet_layer_control.parsers.dynamic_param_parsers.__group_box = function(layer
 }
 
 leaflet_layer_control.parsers.dynamic_param_parsers.String = function(layer, param) {
+    "use strict";
     var input = document.createElement("input");
     input.type = "text";
     input.className = "input-small";
@@ -989,13 +993,14 @@ leaflet_layer_control.parsers.dynamic_param_parsers.String = function(layer, par
 };
 
 leaflet_layer_control.parsers.dynamic_param_parsers.Date = function(layer, param) {
+    "use strict";
     var input = document.createElement("input");
     input.type = "date";
     input.className = "input-medium";
     input.value = layer.config.layerParams[param.name];
     
     if (param.range) {
-        rangeFun = leaflet_layer_control.parsers.dynamic_param_ranges[param.range.type];
+        var rangeFun = leaflet_layer_control.parsers.dynamic_param_ranges[param.range.type];
         if (rangeFun) rangeFun(input, param.range);
     }
 
@@ -1003,6 +1008,7 @@ leaflet_layer_control.parsers.dynamic_param_parsers.Date = function(layer, param
 };
 
 leaflet_layer_control.parsers.dynamic_param_parsers.Number = function(layer, param) {
+    "use strict";
     if (window.Slider && param.range) {
         var input = document.createElement("input");
         input.type = "number";
@@ -1012,7 +1018,7 @@ leaflet_layer_control.parsers.dynamic_param_parsers.Number = function(layer, par
         var wrapper = leaflet_layer_control.parsers.dynamic_param_parsers.__group_box(layer, param, input);
 
         if (param.range) {
-            rangeFun = leaflet_layer_control.parsers.dynamic_param_ranges[param.range.type];
+            var rangeFun = leaflet_layer_control.parsers.dynamic_param_ranges[param.range.type];
             if (rangeFun) rangeFun(input, param.range, function() {
                 if (input.min && input.max) { // Only create slider if we have a MIN and max
                     new Slider(input, {
@@ -1033,7 +1039,7 @@ leaflet_layer_control.parsers.dynamic_param_parsers.Number = function(layer, par
         input.value = layer.config.layerParams[param.name];
 
         if (param.range) {
-            rangeFun = leaflet_layer_control.parsers.dynamic_param_ranges[param.range.type];
+            var rangeFun = leaflet_layer_control.parsers.dynamic_param_ranges[param.range.type];
             if (rangeFun) rangeFun(input, param.range);
         }
 
@@ -1044,6 +1050,7 @@ leaflet_layer_control.parsers.dynamic_param_parsers.Number = function(layer, par
 leaflet_layer_control.parsers.dynamic_param_ranges = {};
 
 leaflet_layer_control.parsers.dynamic_param_ranges.FixedRange = function(numberInput, range, callback) {
+    "use strict";
     numberInput.min = range.start;
     numberInput.max = range.end;
     numberInput.step = range.step;
@@ -1052,6 +1059,7 @@ leaflet_layer_control.parsers.dynamic_param_ranges.FixedRange = function(numberI
 }
 
 leaflet_layer_control.parsers.dynamic_param_ranges.NumberCapIDRange = function(numberInput, range, callback) {
+    "use strict";
     $.ajax({
             url: range.url,
             dataType: "json"

--- a/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
+++ b/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
@@ -1485,13 +1485,6 @@ leaflet_layer_control.drawEachLayer=function(data,map,doNotMoveToTop){
             var layer = layer_obj.data;
 
             aoi_feature_edit.map.removeLayer(layer);
-        } else if (layer_obj.children && layer_obj.children.length) {
-            //A category was clicked
-            
-            // we shouldn't need this in selectmode 3
-            // _.each(layer_obj.children, function(layer_obj_item){
-            //     layer_obj_item.setSelected(false);
-            // });
         }
     });
 
@@ -1557,11 +1550,7 @@ leaflet_layer_control.drawEachLayer=function(data,map,doNotMoveToTop){
             }
 
         } else if (layer_obj.children && layer_obj.children.length) {
-            //A category was clicked
-            //We shouldn't need this in selectmode 3
-            // _.each(layer_obj.children, function(layer_obj_item){
-            //     layer_obj_item.setSelected(true);
-            // });
+            // A category was clicked, do nothing. (Selectmode 3 will select children).
         } else {
             log.error("A layer with no data was clicked");
         }

--- a/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
+++ b/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
@@ -1124,12 +1124,8 @@ leaflet_layer_control.layerDataList = function (options) {
                 }
 
                 if (showEvenIfNotInUS || layerPreviouslyChosen) {
-                    // FIXME - doesn't work for Social Networking Feeds
                     if (layerPreviouslyChosen) layer_obj.selected = true;
                 }
-                // if (!layer_obj.selected) {
-                //     leaflet_layer_control.setLayerOpacity(layer,0);
-                // }
 
                 //Add this to the json to build the treeview
                 treeData[groupNum].children.push(layer_obj);
@@ -1487,23 +1483,6 @@ leaflet_layer_control.drawEachLayer=function(data,map,doNotMoveToTop){
     _.each(layersUnClicked,function(layer_obj){
         if (layer_obj && layer_obj.data && _.toArray(layer_obj.data).length) {
             var layer = layer_obj.data;
-
-            if (layer.config && layer.config.type === "ESRI Dynamic Map Layer") {
-                // FIXME - The layer control seems to lose 
-                // references to ESRI Dynamic Map Layers
-                // This finds it again.
-                
-                if (layer._currentImage === undefined) {
-                    layer = _.find(_.flatten(aoi_feature_edit.layers),function(l){return l.name==layer.name});
-
-                    if (layer == null) {
-                        log.error("Couldn't recover lost reference to ESRI Dynamic Map Layer!");
-                    } else {
-                        log.warn("Recovered lost reference to ESRI Dynamic Map Layer!");
-                        layer_obj.data = layer; // Save the reference
-                    }
-                }
-            }
 
             aoi_feature_edit.map.removeLayer(layer);
         } else if (layer_obj.children && layer_obj.children.length) {

--- a/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
+++ b/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
@@ -1508,6 +1508,22 @@ leaflet_layer_control.drawEachLayer=function(data,map,doNotMoveToTop){
         if (layer_obj && layer_obj.data && _.toArray(layer_obj.data).length) {
             var layer = layer_obj.data;
 
+            if (layer.config && layer.config.type === "ESRI Dynamic Map Layer") {
+                // FIXME - The layer control seems to lose 
+                // references to ESRI Dynamic Map Layers
+                // This finds it again.
+                
+                if (layer._currentImage === undefined) {
+                    layer = _.find(_.flatten(aoi_feature_edit.layers),function(l){return l.name==layer.name});
+
+                    if (layer == null) {
+                        log.error("Lost reference to ESRI Dynamic Map Layer!");
+                    } else {
+                        layer_obj.data = layer; // Save the reference
+                    }
+                }
+            }
+
             aoi_feature_edit.map.removeLayer(layer);
         } else if (layer_obj.children && layer_obj.children.length) {
             //A category was clicked

--- a/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
+++ b/geoq/core/static/core/js/leafletcontrols/leaflet.layer_tree.js
@@ -811,7 +811,7 @@ leaflet_layer_control.parsers.textIfExists = function(options) {
     var suffix = options.suffix;
 
     var html = "";
-    if (typeof obj != "undefined" && obj !== "") {
+    if (obj != undefined && obj !== "") {
         if (header) {
             html+="<h5>";
         }


### PR DESCRIPTION
Removes layers from map when unchecked (instead of setting opacity to zero).
This has the effect of not issuing network requests or utilizing CPU for unchecked layers.
Layers are added by the layer control exclusively. Layers added elsewhere will result in a situation where the layer can be removed from the map but still will create network requests.

Known Issues: 
The OSM Base layer, since it's added by script generated by django, suffers from the above issue where if it is unchecked, it will not display, but it will still make network requests.
