### PR TITLE
fix apt update problem in base python docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.13
+FROM python:2.7.16
 
 # set appropriately if needed for your environment
 ARG http_proxy


### PR DESCRIPTION
Running `apt update` produces the following error when using `python:2.7.13` as the base image:

```
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)
```

Upgrading to `python:2.7.16` fixes this.